### PR TITLE
Fix visitor inheritance

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Ruby/Ruby.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Ruby/Ruby.stg
@@ -756,7 +756,7 @@ end
 
 ListenerDispatchMethod(method) ::= <<
 def <if(method.isEnter)>enter<else>exit<endif>_rule( listener)
-	if ( listener.is_a? <parser.grammarName>Listener )
+	if ( listener.respond_to?(:<if(method.isEnter)>enter<else>exit<endif><struct.derivedFromName; format="cap">) )
 	  listener.<if(method.isEnter)>enter<else>exit<endif><struct.derivedFromName; format="cap">(self)
 	end
 end
@@ -765,7 +765,7 @@ end
 VisitorDispatchMethod(method) ::= <<
 
 def accept(visitor)
-	if ( visitor.is_a? <parser.grammarName>Visitor )
+	if ( visitor.respond_to?(:visit<struct.derivedFromName; format="cap">) )
 	  return visitor.visit<struct.derivedFromName; format="cap">(self)
 	else
 	 return visitor.visit_children(self)


### PR DESCRIPTION
Hey @twalmsley, I've been continuing to play around with antlr4-ruby-runtime and am finding it very well done. However think I've stumbled upon an issue in one of the ANTLR string templates. I tried creating a basic visitor that inherits from the `PythonBaseVisitor` that ANTLR generates, but none of my `visit*` methods were getting called. Perplexed, I decided to investigate.

I discovered that each context object contains an accept method that looks like this:

```ruby
def accept(visitor)
  if (visitor.is_a? Python3Visitor)
    return visitor.visitSingle_input(self)
  else
    return visitor.visit_children(self)
  end
end
```

Since my visitor inherits from `PythonBaseVisitor` which itself inherits from `Antlr4::Runtime::AbstractParseTreeVisitor`, my visitor doesn't have `Python3Visitor` anywhere in its inheritance chain, which causes the `is_a?` call above to return `false`. So instead of calling the visitor method `visitSingle_input`, `accept` ends up calling the default `visit_children`.

In the equivalent Python parser generated by the Java version of ANTLR, `PythonBaseVisitor` extends `AbstractParseTreeVisitor` _and_ implements `Python3Visitor` _which is a Java interface_. This means Java's generated `accept` methods can check whether or not the visitor inherits from `Python3Visitor` to know if it includes the `visitSingle_input` method:

```java
public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
    return visitor instanceof Python3Visitor ? ((Python3Visitor)visitor).visitSingle_input(this) : visitor.visitChildren(this);
}
```

Checking the type is only necessary in Java because the visitor has to be cast to the `Python3Visitor` interface in order to call the `visitSingle_input` method.

So what should we do for Ruby? Ruby doesn't really support interfaces, and while we technically could turn `Python3Visitor` into a module and `include` it in the base visitor, that doesn't feel particularly Ruby-like. We should be able to pass whatever sort of object we want into the `accept` method.

My proposal is to check to see if the visitor object responds to the `visit*` method in question. If it doesn't, then call `visit_children`. That way we don't have to worry about requiring our visitors include a module as well as inherit from a class. We might even be able to do away with `Python3Visitor` altogether since it doesn't really do anything.

Let me know what you think!