### PR TITLE
Fix multi-option case statements

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Ruby/Ruby.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Ruby/Ruby.stg
@@ -525,7 +525,7 @@ end
 
 Sync(s) ::= "sync(<s.expecting.name>);"
 
-ThrowNoViableAlt(t) ::= "raise Antlr4::Runtime::NoViableAltException self"
+ThrowNoViableAlt(t) ::= "raise Antlr4::Runtime::NoViableAltException, self"
 
 TestSetInline(s) ::= <<
 <s.bitsets:{bits | <if(rest(rest(bits.ttypes)))><bitsetBitfieldComparison(s, bits)><else><bitsetInlineComparison(s, bits)><endif>}; separator=" || ">
@@ -556,7 +556,7 @@ bitsetInlineComparison(s, bits) ::= <%
 %>
 
 cases(ttypes) ::= <<
-<ttypes:{t | when <t>}; separator="\n">
+when <ttypes:{t | <t>}; separator=", ">
 >>
 
 InvokeRule(r, argExprsChunks) ::= <<


### PR DESCRIPTION
This addresses an issue with generated Ruby `case` statements. Here's how they currently look when generating `LL1AltBlock`s:

```ruby
case (@_input.la(1))
when FIRST_ALT
when SECOND_ALT
  @_state_number = 123
  next_state()
end
```

This mimics the Java output but works differently. The `FIRST_ALT` and `SECOND_ALT` cases should both result in calling the `next_state()` method, which is what would happen in Java. Ruby however treats these as distinct cases and skips calling `next_state()` in the `FIRST_ALT` case. Instead we need to emit:

```ruby
case (@_input.la(1))
when FIRST_ALT, SECOND_ALT
  @_state_number = 123
  next_state()
end
```